### PR TITLE
Add python 3.7 environment and update incompatible libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,11 @@ for message in consumer:
 # setup versions
 pyenv install 3.5.3
 pyenv install 3.6.3
+pyenv install 3.7.0
 pyenv virtualenv franz 3.5.3
-pyenv local franz 3.5.3 3.6.3
+pyenv local franz 3.5.3 3.6.3 3.7.0
 pip install -r requirements-dev.txt
 
-# run tests (python 3.5 & 3.6)
+# run tests (python 3.5, 3.6, 3.7)
 tox
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-kafka-python==1.3.5
-bson==0.5.0
-pika==0.11.0
+kafka-python==1.4.3
+bson==0.5.6
+pika==0.12.0

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 
-__version__ = "0.0.10"
+__version__ = "0.0.11"
 
 
 setup(
@@ -21,9 +21,9 @@ setup(
     license="MIT",
     keywords="microservices broker event kafka rabbitmq",
     install_requires=[
-        "kafka-python==1.3.5",
-        "bson==0.5.0",
-        "pika==0.11.0",
+        "kafka-python==1.4.3",
+        "bson==0.5.6",
+        "pika==0.12.0",
     ],
     packages=[
         "franz",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{35,36}
+envlist = py{35,36,37}
 
 [testenv]
 deps=-rrequirements-dev.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{35,36,37}
+envlist = py35, py36, py37
 
 [testenv]
 deps=-rrequirements-dev.txt


### PR DESCRIPTION
- Update dependencies: kafka-python, bson, pika to versions 3.7-compatible
- Update tox config to add tests on 3.7 environment
- Bumps version to 0.0.11