### PR TITLE
Add CircleCI [WIP]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,40 @@
+# Python CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-python/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version you desire here
+      # use `-browsers` prefix for selenium tests, e.g. `3.6.1-browsers`
+      - image: circleci/python:3.6.5
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      - run:
+          name: install dependencies
+          command: |
+            pip install -r requirements-dev.txt
+
+      - save_cache:
+          paths:
+            - ./venv
+          key: v1-dependencies-{{ checksum "requirements-dev.txt" }}
+        
+      # run tests!
+      # this example uses Django's built-in test-runner
+      # other common Python testing frameworks include pytest and nose
+      # https://pytest.org
+      # https://nose.readthedocs.io
+      - run:
+          name: run tests
+          command: |
+            tox
+
+      - store_artifacts:
+          path: test-reports
+          destination: test-reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ shared: &shared
   - run:
       name: run tests
       command: |
-        pytest tests
+        python -m pytest tests
 
   - store_artifacts:
       path: test-reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,11 @@ jobs:
       # use `-browsers` prefix for selenium tests, e.g. `3.6.1-browsers`
       - image: circleci/python:3.7.0
 
+  "testing":
+    <<: *shared
+    docker:
+      - image: erickmendonca/python-kafka-ci:lastest
+
 
 workflows:
   version: 2
@@ -63,3 +68,4 @@ workflows:
       - "python3.5"
       - "python3.6"
       - "python3.7"
+      - "testing"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,14 +15,10 @@ jobs:
     steps:
       - checkout
 
-      - install_python_versions:
-          command: |
-            pyenv install 3.5.3 && pyenv install 3.6.3 && pyenv install 3.7.0 && pyenv virtualenv franz 3.5.3 && pyenv local franz 3.5.3 3.6.3 3.7.0
-
       - run:
           name: install dependencies
           command: |
-            pip install -r requirements-dev.txt
+            pyenv install 3.5.3 && pyenv install 3.6.3 && pyenv install 3.7.0 && pyenv virtualenv franz 3.5.3 && pyenv local franz 3.5.3 3.6.3 3.7.0 && pip install -r requirements-dev.txt
 
       - save_cache:
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,11 +17,7 @@ jobs:
 
       - install_python_versions:
         command: |
-          pyenv install 3.5.3
-          pyenv install 3.6.3
-          pyenv install 3.7.0
-          pyenv virtualenv franz 3.5.3
-          pyenv local franz 3.5.3 3.6.3 3.7.0
+          pyenv install 3.5.3 && pyenv install 3.6.3 && pyenv install 3.7.0 && pyenv virtualenv franz 3.5.3 && pyenv local franz 3.5.3 3.6.3 3.7.0
 
       - run:
           name: install dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,8 +16,8 @@ jobs:
       - checkout
 
       - install_python_versions:
-        command: |
-          pyenv install 3.5.3 && pyenv install 3.6.3 && pyenv install 3.7.0 && pyenv virtualenv franz 3.5.3 && pyenv local franz 3.5.3 3.6.3 3.7.0
+          command: |
+            pyenv install 3.5.3 && pyenv install 3.6.3 && pyenv install 3.7.0 && pyenv virtualenv franz 3.5.3 && pyenv local franz 3.5.3 3.6.3 3.7.0
 
       - run:
           name: install dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ shared: &shared
   - run:
       name: install franz
       command: |
-        pip install -e .
+        pip install -e . --user
 
   - save_cache:
       paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,38 +3,54 @@
 # Check https://circleci.com/docs/2.0/language-python/ for more details
 #
 version: 2
+
+shared: &shared
+  working_directory: ~/repo
+  steps:
+  - checkout
+
+  - run:
+      name: install dependencies
+      command: |
+        pip install -r requirements-dev.txt
+
+  - run:
+      name: install franz
+      command: |
+        pip install -e .
+
+  - save_cache:
+      paths:
+        - ./venv
+      key: v1-dependencies-{{ checksum "requirements-dev.txt" }}
+    
+  - run:
+      name: run tests
+      command: |
+        pytest tests
+
+  - store_artifacts:
+      path: test-reports
+      destination: test-reports
+
 jobs:
-  build:
+  "python3.5":
+    <<: *shared
     docker:
       # specify the version you desire here
       # use `-browsers` prefix for selenium tests, e.g. `3.6.1-browsers`
-      - image: circleci/python:3.6.5
+      - image: circleci/python:3.5.3
 
-    working_directory: ~/repo
+  "python3.6":
+    <<: *shared
+    docker:
+      # specify the version you desire here
+      # use `-browsers` prefix for selenium tests, e.g. `3.6.1-browsers`
+      - image: circleci/python:3.6.3
 
-    steps:
-      - checkout
-
-      - run:
-          name: install dependencies
-          command: |
-            pyenv install 3.5.3 && pyenv install 3.6.3 && pyenv install 3.7.0 && pyenv virtualenv franz 3.5.3 && pyenv local franz 3.5.3 3.6.3 3.7.0 && pip install -r requirements-dev.txt
-
-      - save_cache:
-          paths:
-            - ./venv
-          key: v1-dependencies-{{ checksum "requirements-dev.txt" }}
-        
-      # run tests!
-      # this example uses Django's built-in test-runner
-      # other common Python testing frameworks include pytest and nose
-      # https://pytest.org
-      # https://nose.readthedocs.io
-      - run:
-          name: run tests
-          command: |
-            tox
-
-      - store_artifacts:
-          path: test-reports
-          destination: test-reports
+  "python3.7":
+    <<: *shared
+    docker:
+      # specify the version you desire here
+      # use `-browsers` prefix for selenium tests, e.g. `3.6.1-browsers`
+      - image: circleci/python:3.7.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,3 +54,12 @@ jobs:
       # specify the version you desire here
       # use `-browsers` prefix for selenium tests, e.g. `3.6.1-browsers`
       - image: circleci/python:3.7.0
+
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - "python3.5"
+      - "python3.6"
+      - "python3.7"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
   "testing":
     <<: *shared
     docker:
-      - image: erickmendonca/python-kafka-ci:lastest
+      - image: erickmendonca/python-kafka-ci:latest
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ shared: &shared
   - run:
       name: install dependencies
       command: |
-        pip install -r requirements-dev.txt
+        pip install -r requirements-dev.txt --user
 
   - run:
       name: install franz

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,14 @@ jobs:
     steps:
       - checkout
 
+      - install_python_versions:
+        command: |
+          pyenv install 3.5.3
+          pyenv install 3.6.3
+          pyenv install 3.7.0
+          pyenv virtualenv franz 3.5.3
+          pyenv local franz 3.5.3 3.6.3 3.7.0
+
       - run:
           name: install dependencies
           command: |


### PR DESCRIPTION
- [x] Add CircleCI config file
- [x] Setup multiple environment testing (unit testing and installing library)
- [ ] Installing kafka and dependencies on docker images used by CircleCI

Reference links:
 - Kafka docker image: https://hub.docker.com/r/spotify/kafka/
 - Python docker image: https://github.com/CircleCI-Public/circleci-dockerfiles/blob/master/python/images/3.7.0/Dockerfile
 - Using custom images on CircleCI: https://circleci.com/docs/2.0/custom-images/